### PR TITLE
Add backspace and delete to nav layout

### DIFF
--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -76,14 +76,14 @@
         //╭──────────┬──────────┬──────────┬──────────┬──────────╮   ╭──────────┬──────────┬──────────┬──────────┬──────────╮
         //│          │          │          │          │          │   │  =       │  7       │  8       │  9       │  +       │
         //├──────────┼──────────┼──────────┼──────────┼──────────┤   ├──────────┼──────────┼──────────┼──────────┼──────────┤
-        //│ Shift    │  Ctrl    │  Alt     │  Gui     │          │   │  0       │  1       │  2       │  3       │  -       │
+        //│ Shift    │  Ctrl    │  Alt     │  Gui     │  DEMO    │   │  0       │  1       │  2       │  3       │  -       │
         //├──────────┼──────────┼──────────┼──────────┼──────────┤   ├──────────┼──────────┼──────────┼──────────┼──────────┤
         //│          │          │          │          │          │   │  *       │  4       │  5       │  6       │  /       │
         //╰──────────┴──────────┴──────────┼──────────┼──────────┤   ├──────────┼──────────┼──────────┴──────────┴──────────╯
         //                                 │          │          │   │          │  *****   │ 
         //                                 ╰──────────┴──────────╯   ╰──────────┴──────────╯
             &trans     &trans      &trans     &trans     &trans         &kp EQUAL  &kp N7  &kp N8     &kp N9     &kp KP_PLUS  
-            LS_MT_SK   LC_MT_SK    LA_MT_SK   LG_MT_SK   &trans         &kp N0     &kp N1  &kp N2     &kp N3     &kp MINUS 
+            LS_MT_SK   LC_MT_SK    LA_MT_SK   LG_MT_SK   &demo          &kp N0     &kp N1  &kp N2     &kp N3     &kp MINUS 
             &trans     &trans      &trans     &trans     &trans         &kp ASTRK  &kp N4  &kp N5     &kp N6     &kp KP_DIVIDE 
                                               &trans     &trans         &trans     &trans
             >;
@@ -92,17 +92,17 @@
         tri_layer {
             bindings = <
         //╭──────────┬──────────┬──────────┬──────────┬──────────╮   ╭──────────┬──────────┬──────────┬──────────┬──────────╮
-        //│  Esc     │          │          │          │  Paste   │   │  Stop    │  PREV    │  Play    │  Next    │  Bspc    │
+        //│  Esc     │          │          │          │  DEL     │   │  Stop    │  PREV    │  Play    │  Next    │          │
         //├──────────┼──────────┼──────────┼──────────┼──────────┤   ├──────────┼──────────┼──────────┼──────────┼──────────┤
-        //│  Shift   │  Ctrl    │  Alt     │  Gui     │  Tab     │   │  Left    │  Down    │  Up      │  Right   │  Ent     │
+        //│  Shift   │  Ctrl    │  Alt     │  Gui     │  BSPC    │   │  Left    │  Down    │  Up      │  Right   │  Ent     │
         //├──────────┼──────────┼──────────┼──────────┼──────────┤   ├──────────┼──────────┼──────────┼──────────┼──────────┤
-        //│          │          │          │          │  Copy    │   │  Tab     │  Vol-    │  Mute    │  Vol+    │  Del     │
+        //│          │          │          │          │          │   │  Tab     │  Vol-    │  Mute    │  Vol+    │          │
         //╰──────────┴──────────┴──────────┼──────────┼──────────┤   ├──────────┼──────────┼──────────┴──────────┴──────────╯
         //                                 │  *****   │          │   │          │  *****   │ 
         //                                 ╰──────────┴──────────╯   ╰──────────┴──────────╯
-            &kp ESC    &trans      &trans     &trans     &kp K_PASTE    &kp C_STOP &kp C_PREV &kp C_PLAY &kp C_NEXT &kp BSPC 
-            LS_MT_SK   LC_MT_SK    LA_MT_SK   LG_MT_SK   &kp K_COPY     &kp LEFT   &kp DOWN   &kp UP     &kp RIGHT  &kp ENTER  
-            &trans     &trans      &trans     &trans     &trans         &kp TAB    &kp C_VOL_DN  &kp C_MUTE  &kp C_VOL_UP  &kp DEL 
+            &kp ESC    &trans      &trans     &trans     &kp DEL        &kp C_STOP &kp C_PREV &kp C_PLAY &kp C_NEXT &trans 
+            LS_MT_SK   LC_MT_SK    LA_MT_SK   LG_MT_SK   &kp BSPC       &kp LEFT   &kp DOWN   &kp UP     &kp RIGHT  &kp ENTER  
+            &trans     &trans      &trans     &trans     &trans         &kp TAB    &kp C_VOL_DN  &kp C_MUTE  &kp C_VOL_UP  &trans
                                               &trans     &trans         &trans     &trans
             >;
         };


### PR DESCRIPTION
## What does this PR do?
PR adds backspace and delete to the navigation layout as de `BSPC` from the default layer can only be tapped.